### PR TITLE
Fixed Cost function in QP formulation generation.

### DIFF
--- a/problem_classes/control.py
+++ b/problem_classes/control.py
@@ -88,7 +88,8 @@ class ControlExample(object):
         (nx, nu) = self.B.shape
 
         # Objective
-        Px = spa.kron(spa.eye(self.T), self.Q)
+        eye_with_no_cost_for_x0 = spa.diags([int(i != 0) for i in range(self.T)]) # equals diag([0,1,1,1, ... , 1])
+        Px = spa.kron(eye_with_no_cost_for_x0, self.Q)
         Pu = spa.kron(spa.eye(self.T), self.R)
         P = 2. * spa.block_diag([Px, self.QN, Pu]).tocsc()
         q = np.zeros((self.T + 1) * nx + self.T * nu)


### PR DESCRIPTION
The cost function adds cost on the inital state x_0 that is constraint to be equal to x_init. Now we just make the initial cost to be 0. This will result in a sparser system and therefor in faster execution and less memory ussage. Even though the argument can be made that the change is negligible.

I hope this change helps anybody that uses this code to generate a QP problem from an MPC one.